### PR TITLE
Update r-base version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ USER jovyan
 
 # R packages
 RUN conda install --quiet --yes \
-    'r-base=4.0.0' \
+    'r-base=4.0.3' \
     'r-caret=6.*' \
     'r-crayon=1.3*' \
     'r-devtools=2.3*' \


### PR DESCRIPTION
To address `/opt/conda/lib/R/library/Rcpp/libs/Rcpp.so: undefined symbol: EXTPTR_PTR` error. Suggested solution is to update r version. https://community.rstudio.com/t/package-manager-and-travis/73816